### PR TITLE
Adds update and delete actions to AbstractDAO, fixes #27.

### DIFF
--- a/Sogifty/src/main/java/com/sogifty/dao/dto/DTO.java
+++ b/Sogifty/src/main/java/com/sogifty/dao/dto/DTO.java
@@ -1,0 +1,6 @@
+package com.sogifty.dao.dto;
+
+public interface DTO {
+	// Ensures AbstractDAO that getId is always accessible in a DTO object
+	public Integer getId();
+}

--- a/Sogifty/src/main/java/com/sogifty/dao/dto/User.java
+++ b/Sogifty/src/main/java/com/sogifty/dao/dto/User.java
@@ -9,7 +9,7 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "app_user")
-public class User {
+public class User implements DTO {
 	
 	@Id
 	@Column(name = "id")


### PR DESCRIPTION
Fixe #27

Je ne voulais pas tester ça sur User en créant des webservices qu'on n'utilisera jamais, aussi il est possible que update et delete ne fonctionnent pas tout à fait correctement pour le moment, mais on va merger cette pull request si ça paraît bon pour tout le monde a priori et vraiment mettre ce code à l'épreuve avec le webservice pour les amis, où on aura de la modification et de la suppression.

Les méthodes update et delete ici recquierent que l'id de l'objet à mettre à jour ou à supprimer ait été initialisé avant, ce que l'on fera dans le webservice par un User.setId(...) puisqu'on obtiendra l'identifiant en question par l'URL. En effet, si on veut rester dans le cadre du REST, l'URL pour mettre à jour un objet sera du /objet/{id}/update et pour le supprimer ce devrait être du DELETE (et non POST) sur /objet/{id} (à voir si envoyer une requête DELETE depuis Android est faisable ou si on part plutôt sur du POST sur /objet/{id}/delete).

Si on n'a pas d'identifiant dans l'objet passé, alors on aura une bonne vieille SogiftyException retournant une erreur 404.
